### PR TITLE
[config] add configuration system to define application settings

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ pytest-cov = "*"
 tox = "*"
 flake8 = "*"
 elmo = {editable = true,path = "."}
+pytest-mock = "*"
 
 [packages]
 requests = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ pytest = "*"
 pytest-cov = "*"
 tox = "*"
 flake8 = "*"
+elmo = {editable = true,path = "."}
 
 [packages]
 requests = "*"

--- a/elmo/conf/__init__.py
+++ b/elmo/conf/__init__.py
@@ -1,0 +1,5 @@
+from .base import BaseSettings
+from .options import Option
+
+
+__all__ = [BaseSettings, Option]

--- a/elmo/conf/base.py
+++ b/elmo/conf/base.py
@@ -2,14 +2,14 @@ from .options import Option
 from .exceptions import OptionNotAvailable, ConfigNotValid
 
 
-class BaseConfig(object):
+class BaseSettings(object):
     """Configuration base class that must be extended to define application settings.
     Every setting must be of type ``Option`` otherwise it's not taken in consideration
     during the validation process.
 
     Example:
 
-        class Settings(BaseConfig):
+        class Settings(BaseSettings):
             url = Option()
             dry_run = Option(validators=[is_a_boolean])
 

--- a/elmo/conf/config.py
+++ b/elmo/conf/config.py
@@ -1,0 +1,92 @@
+from .options import Option
+from .exceptions import OptionNotAvailable
+
+
+class BaseConfig(object):
+    """Configuration base class that must be extended to define application settings.
+    Every setting must be of type ``Option`` otherwise it's not taken in consideration
+    during the validation process.
+
+    Example:
+
+        class Settings(BaseConfig):
+            url = Option()
+            dry_run = Option(validators=[is_a_boolean])
+
+        settings = Settings()
+        settings.url = "http://example.com""
+        settings.dry_run = False
+        settings.is_valid()  # returns True
+    """
+
+    def __init__(self):
+        """Store options defined as class attributes in a local registry."""
+        self._options = []
+        for attr, value in self.__class__.__dict__.items():
+            option = self._get_option(attr)
+            if isinstance(option, Option):
+                self._options.append(attr)
+
+    def __setattr__(self, name, value):
+        """Config attributes must be of type Option. This setattr() ensures that the
+        Option.value is properly set.
+
+        Args:
+            name: the name of the attribute.
+            value: the value of the attribute.
+        Raise:
+            OptionNotAvailable: set attribute is not present as class Attribute.
+        """
+        if name == "_options":
+            object.__setattr__(self, name, value)
+            return
+
+        if name in object.__getattribute__(self, "_options"):
+            option = self._get_option(name)
+            option.value = value
+        else:
+            raise OptionNotAvailable("the option is not present in the current config")
+
+    def __getattribute__(self, name):
+        """Config attributes must be of type Option. This getattr() ensures that the
+        Option.value is properly get.
+
+        Args:
+            name: the attribute name to retrieve.
+        Return:
+            The Option value if the attribute is in the options list. Otherwise
+            ``object.__getattribute__()`` is called.
+        """
+        if name in object.__getattribute__(self, "_options"):
+            option = self._get_option(name)
+            return option.value
+        else:
+            return object.__getattribute__(self, name)
+
+    def __getattr__(self, name):
+        """``__getattr__`` is called whenever the ``__getattribute__()`` didn't
+        find the attribute. In that case it means the given attribute is not
+        a configuration option that was defined as class attributes.
+
+        Args:
+            name: the attribute name to retrieve.
+        Raise:
+            OptionNotAvailable: the configuration option is not present.
+        """
+        raise OptionNotAvailable("the option is not present in the current config")
+
+    def _get_option(self, name):
+        """Retrieve the Option instance instead of proxying the call to retrieve
+        the ``Option.value``.
+
+        Args:
+            name: the ``Option`` name.
+
+        Return:
+            An ``Option`` instance.
+        """
+        return object.__getattribute__(self, name)
+
+    def is_valid(self, raise_exception=True):
+        """TODO: missing implementation"""
+        pass

--- a/elmo/conf/config.py
+++ b/elmo/conf/config.py
@@ -1,5 +1,5 @@
 from .options import Option
-from .exceptions import OptionNotAvailable, ValidationError
+from .exceptions import OptionNotAvailable, ConfigNotValid
 
 
 class BaseConfig(object):
@@ -108,7 +108,7 @@ class BaseConfig(object):
 
         is_valid = len(errors) == 0
         if not is_valid and raise_exception is True:
-            raise ValidationError(
+            raise ConfigNotValid(
                 "Validators for these options have failed: {}".format(errors)
             )
 

--- a/elmo/conf/exceptions.py
+++ b/elmo/conf/exceptions.py
@@ -1,4 +1,4 @@
-class InvalidConfig(Exception):
+class ValidationError(Exception):
     """The configuration is not valid."""
 
     pass

--- a/elmo/conf/exceptions.py
+++ b/elmo/conf/exceptions.py
@@ -1,5 +1,11 @@
 class ValidationError(Exception):
-    """The configuration is not valid."""
+    """Exception raised when a Validator fails."""
+
+    pass
+
+
+class ConfigNotValid(Exception):
+    """Exception raised when any validator fails for a Config object."""
 
     pass
 

--- a/elmo/conf/exceptions.py
+++ b/elmo/conf/exceptions.py
@@ -2,3 +2,9 @@ class InvalidConfig(Exception):
     """The configuration is not valid."""
 
     pass
+
+
+class OptionNotAvailable(Exception):
+    """The Option is not available in the current configuration."""
+
+    pass

--- a/elmo/conf/exceptions.py
+++ b/elmo/conf/exceptions.py
@@ -1,0 +1,4 @@
+class InvalidConfig(Exception):
+    """The configuration is not valid."""
+
+    pass

--- a/elmo/conf/options.py
+++ b/elmo/conf/options.py
@@ -1,26 +1,11 @@
-from .exceptions import InvalidConfig
-
-
 class Option(object):
     """Settings option that includes built-in validation."""
 
-    def __init__(
-        self,
-        read_only=False,
-        required=False,
-        default=None,
-        allow_null=True,
-        validators=None,
-    ):
+    def __init__(self, default=None, allow_null=True, validators=None):
         """Initialize the option field with permissive defaults.
         By default the field is not required and None value is permitted.
         """
-        # Assert invalid kwargs
-        if required and not default:
-            raise InvalidConfig("Required option cannot default to empty value")
-
-        self.read_only = read_only
-        self.required = required
+        self.value = default if default else None
         self.default = default
         self.allow_null = allow_null
 
@@ -28,3 +13,20 @@ class Option(object):
             self.validators = list(validators)
         else:
             self.validators = []
+
+    def _validate(self):
+        """Validate this Option based on attributes and validators.
+
+        Return:
+            A boolean that is True if the option honors all validators, False otherwise.
+        """
+        failed_validators = []
+        if self.allow_null is False and self.value is None:
+            failed_validators.append("allow_null")
+
+        for validator in self.validators:
+            if validator(self.value) is False:
+                failed_validators.append(validator.__name__)
+
+        is_valid = len(failed_validators) == 0
+        return is_valid, failed_validators

--- a/elmo/conf/options.py
+++ b/elmo/conf/options.py
@@ -1,0 +1,30 @@
+from .exceptions import InvalidConfig
+
+
+class Option(object):
+    """Settings option that includes built-in validation."""
+
+    def __init__(
+        self,
+        read_only=False,
+        required=False,
+        default=None,
+        allow_null=True,
+        validators=None,
+    ):
+        """Initialize the option field with permissive defaults.
+        By default the field is not required and None value is permitted.
+        """
+        # Assert invalid kwargs
+        if required and not default:
+            raise InvalidConfig("Required option cannot default to empty value")
+
+        self.read_only = read_only
+        self.required = required
+        self.default = default
+        self.allow_null = allow_null
+
+        if validators is not None:
+            self.validators = list(validators)
+        else:
+            self.validators = []

--- a/elmo/conf/validators.py
+++ b/elmo/conf/validators.py
@@ -1,0 +1,34 @@
+from urllib.parse import urlparse
+
+from .exceptions import ValidationError
+
+
+def not_null(value):
+    """Validate if Option is not None.
+    Args:
+        value: the Option value.
+    Raises:
+        ValidationError: if the Option is None
+    """
+    if value is None or value == "":
+        raise ValidationError("The value must not be None")
+
+    return True
+
+
+def is_https_url(value):
+    """Validate if the Option is a valid URL with HTTPS schema.
+
+    Args:
+        value: the Option value.
+    Raises:
+        ValidationError: if the Option is not a valid URL with 'https' schema
+    """
+    url = urlparse(value)
+    if url.scheme != "https":
+        raise ValidationError("The schema must be HTTPS")
+
+    if url.netloc is None:
+        raise ValidationError("The URL is missing the net location")
+
+    return True

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,3 +1,0 @@
-def test_base():
-    """Example test to configure testing env"""
-    assert 42 == 42

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,7 @@ import pytest
 
 from elmo.conf.config import BaseConfig
 from elmo.conf.options import Option
-from elmo.conf.exceptions import OptionNotAvailable
+from elmo.conf.exceptions import OptionNotAvailable, ValidationError
 
 
 def test_config_constructor():
@@ -61,3 +61,74 @@ def test_config_get_value_not_available():
     config = ConfigTest()
     with pytest.raises(OptionNotAvailable):
         config.test
+
+
+def test_config_is_valid_all_options(mocker):
+    """Should validate all Option attributes"""
+
+    class ConfigTest(BaseConfig):
+        option1 = Option()
+        option2 = Option()
+
+    config = ConfigTest()
+    option1 = config._get_option("option1")
+    option2 = config._get_option("option2")
+
+    # Mock config options
+    mocker.patch.object(option1, "_validate", return_value=(True, []))
+    mocker.patch.object(option2, "_validate", return_value=(True, []))
+
+    config.is_valid()
+    assert option1._validate.call_count == 1
+    assert option2._validate.call_count == 1
+
+
+def test_config_is_valid(mocker):
+    """Should return a success if the configuration is valid"""
+
+    class ConfigTest(BaseConfig):
+        home = Option()
+
+    config = ConfigTest()
+    option = config._get_option("home")
+
+    # Mock config options
+    mocker.patch.object(option, "_validate", return_value=(True, []))
+
+    assert config.is_valid() == (True, [])
+
+
+def test_config_is_not_valid(mocker):
+    """Should return a failure if the configuration is not valid and raise_exception is False"""
+
+    class ConfigTest(BaseConfig):
+        home = Option()
+
+    config = ConfigTest()
+    option = config._get_option("home")
+
+    # Mock config options
+    mocker.patch.object(
+        option, "_validate", return_value=(False, ["allow_null", "validator"])
+    )
+
+    assert config.is_valid(raise_exception=False) == (
+        False,
+        [{"home": ["allow_null", "validator"]}],
+    )
+
+
+def test_config_is_not_valid_exception(mocker):
+    """Should raise an exception if the configuration is not valid and raise_exception is True"""
+
+    class ConfigTest(BaseConfig):
+        home = Option()
+
+    config = ConfigTest()
+    option = config._get_option("home")
+
+    # Mock config options
+    mocker.patch.object(option, "_validate", return_value=(False, ["validator"]))
+
+    with pytest.raises(ValidationError):
+        assert config.is_valid()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,6 @@
 import pytest
 
-from elmo.conf.config import BaseConfig
+from elmo.conf.base import BaseSettings
 from elmo.conf.options import Option
 from elmo.conf.exceptions import OptionNotAvailable, ConfigNotValid
 
@@ -8,22 +8,22 @@ from elmo.conf.exceptions import OptionNotAvailable, ConfigNotValid
 def test_config_constructor():
     """Should contain options registry only for attributes of type Option"""
 
-    class ConfigTest(BaseConfig):
+    class SettingsTest(BaseSettings):
         home = Option()
         url = Option()
         objects = []
 
-    config = ConfigTest()
+    config = SettingsTest()
     assert config._options == ["home", "url"]
 
 
 def test_config_set_value():
     """Should set the underlying Option value"""
 
-    class ConfigTest(BaseConfig):
+    class SettingsTest(BaseSettings):
         home = Option()
 
-    config = ConfigTest()
+    config = SettingsTest()
     config.home = "test"
     option = config._get_option("home")
     assert option.value == "test"
@@ -32,10 +32,10 @@ def test_config_set_value():
 def test_config_get_value():
     """Should get the underlying Option value"""
 
-    class ConfigTest(BaseConfig):
+    class SettingsTest(BaseSettings):
         home = Option()
 
-    config = ConfigTest()
+    config = SettingsTest()
     option = config._get_option("home")
     option.value = "test"
     assert config.home == "test"
@@ -44,10 +44,10 @@ def test_config_get_value():
 def test_config_set_value_not_available():
     """Should raise an exception if the option is not present"""
 
-    class ConfigTest(BaseConfig):
+    class SettingsTest(BaseSettings):
         pass
 
-    config = ConfigTest()
+    config = SettingsTest()
     with pytest.raises(OptionNotAvailable):
         config.test = "test"
 
@@ -55,10 +55,10 @@ def test_config_set_value_not_available():
 def test_config_get_value_not_available():
     """Should raise an exception if the option is not present"""
 
-    class ConfigTest(BaseConfig):
+    class SettingsTest(BaseSettings):
         pass
 
-    config = ConfigTest()
+    config = SettingsTest()
     with pytest.raises(OptionNotAvailable):
         config.test
 
@@ -66,11 +66,11 @@ def test_config_get_value_not_available():
 def test_config_is_valid_all_options(mocker):
     """Should validate all Option attributes"""
 
-    class ConfigTest(BaseConfig):
+    class SettingsTest(BaseSettings):
         option1 = Option()
         option2 = Option()
 
-    config = ConfigTest()
+    config = SettingsTest()
     option1 = config._get_option("option1")
     option2 = config._get_option("option2")
 
@@ -86,10 +86,10 @@ def test_config_is_valid_all_options(mocker):
 def test_config_is_valid(mocker):
     """Should return a success if the configuration is valid"""
 
-    class ConfigTest(BaseConfig):
+    class SettingsTest(BaseSettings):
         home = Option()
 
-    config = ConfigTest()
+    config = SettingsTest()
     option = config._get_option("home")
 
     # Mock config options
@@ -101,10 +101,10 @@ def test_config_is_valid(mocker):
 def test_config_is_not_valid(mocker):
     """Should return a failure if the configuration is not valid and raise_exception is False"""
 
-    class ConfigTest(BaseConfig):
+    class SettingsTest(BaseSettings):
         home = Option()
 
-    config = ConfigTest()
+    config = SettingsTest()
     option = config._get_option("home")
 
     # Mock config options
@@ -121,10 +121,10 @@ def test_config_is_not_valid(mocker):
 def test_config_is_not_valid_exception(mocker):
     """Should raise an exception if the configuration is not valid and raise_exception is True"""
 
-    class ConfigTest(BaseConfig):
+    class SettingsTest(BaseSettings):
         home = Option()
 
-    config = ConfigTest()
+    config = SettingsTest()
     option = config._get_option("home")
 
     # Mock config options

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,7 @@ import pytest
 
 from elmo.conf.config import BaseConfig
 from elmo.conf.options import Option
-from elmo.conf.exceptions import OptionNotAvailable, ValidationError
+from elmo.conf.exceptions import OptionNotAvailable, ConfigNotValid
 
 
 def test_config_constructor():
@@ -130,5 +130,5 @@ def test_config_is_not_valid_exception(mocker):
     # Mock config options
     mocker.patch.object(option, "_validate", return_value=(False, ["validator"]))
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(ConfigNotValid):
         assert config.is_valid()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,63 @@
+import pytest
+
+from elmo.conf.config import BaseConfig
+from elmo.conf.options import Option
+from elmo.conf.exceptions import OptionNotAvailable
+
+
+def test_config_constructor():
+    """Should contain options registry only for attributes of type Option"""
+
+    class ConfigTest(BaseConfig):
+        home = Option()
+        url = Option()
+        objects = []
+
+    config = ConfigTest()
+    assert config._options == ["home", "url"]
+
+
+def test_config_set_value():
+    """Should set the underlying Option value"""
+
+    class ConfigTest(BaseConfig):
+        home = Option()
+
+    config = ConfigTest()
+    config.home = "test"
+    option = config._get_option("home")
+    assert option.value == "test"
+
+
+def test_config_get_value():
+    """Should get the underlying Option value"""
+
+    class ConfigTest(BaseConfig):
+        home = Option()
+
+    config = ConfigTest()
+    option = config._get_option("home")
+    option.value = "test"
+    assert config.home == "test"
+
+
+def test_config_set_value_not_available():
+    """Should raise an exception if the option is not present"""
+
+    class ConfigTest(BaseConfig):
+        pass
+
+    config = ConfigTest()
+    with pytest.raises(OptionNotAvailable):
+        config.test = "test"
+
+
+def test_config_get_value_not_available():
+    """Should raise an exception if the option is not present"""
+
+    class ConfigTest(BaseConfig):
+        pass
+
+    config = ConfigTest()
+    with pytest.raises(OptionNotAvailable):
+        config.test

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,0 +1,36 @@
+import pytest
+
+from elmo.conf.exceptions import InvalidConfig
+from elmo.conf.options import Option
+
+
+def test_default_constructor():
+    """Should create a permissive config option"""
+    option = Option()
+    assert option.read_only == False
+    assert option.required == False
+    assert option.allow_null == True
+    assert option.validators == []
+
+
+def test_invalid_required_default():
+    """Should raise an exception if invalid configuration is used"""
+    with pytest.raises(InvalidConfig):
+        option = Option(required=True)
+
+
+def test_valid_required_default():
+    """Should accept required kwarg with a default"""
+    option = Option(required=True, default="test")
+    assert option.required == True
+    assert option.default == "test"
+
+
+def test_validators_list():
+    """Should expect validators to be a list"""
+
+    def fn():
+        pass
+
+    option = Option(validators=[fn])
+    assert option.validators == [fn]

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,36 +1,97 @@
 import pytest
 
-from elmo.conf.exceptions import InvalidConfig
 from elmo.conf.options import Option
 
 
 def test_default_constructor():
     """Should create a permissive config option"""
     option = Option()
-    assert option.read_only is False
-    assert option.required is False
+    assert option.value is None
+    assert option.default is None
     assert option.allow_null is True
     assert option.validators == []
 
 
-def test_invalid_required_default():
-    """Should raise an exception if invalid configuration is used"""
-    with pytest.raises(InvalidConfig):
-        Option(required=True)
-
-
-def test_valid_required_default():
-    """Should accept required kwarg with a default"""
-    option = Option(required=True, default="test")
-    assert option.required is True
-    assert option.default == "test"
+def test_default_change_value():
+    """Setting a default should change the value"""
+    option = Option(default="test")
+    assert option.value == "test"
 
 
 def test_validators_list():
     """Should expect validators to be a list"""
 
-    def fn():
+    def fn(value):
         pass
 
     option = Option(validators=[fn])
     assert option.validators == [fn]
+
+
+def test_validators_not_alist():
+    """Should fail if validators are not a list"""
+
+    def fn(value):
+        pass
+
+    with pytest.raises(TypeError):
+        Option(validators=fn)
+
+
+def test_validate_ok():
+    """Validate should succeed with permissive defaults"""
+    option = Option()
+    assert option._validate() == (True, [])
+
+
+def test_validate_allow_null_ok():
+    """Validate should succeed if the field has None value"""
+    option = Option(allow_null=True)
+    option.value = None
+    assert option._validate() == (True, [])
+
+
+def test_validate_allow_null_fail():
+    """Validate should fail if the field has None value"""
+    option = Option(allow_null=False)
+    option.value = None
+    assert option._validate() == (False, ["allow_null"])
+
+
+def test_validate_with_validators_ok():
+    """Validate should succeed if validators return True"""
+
+    def v1(value):
+        return True
+
+    def v2(value):
+        return True
+
+    option = Option(validators=[v1, v2])
+    assert option._validate() == (True, [])
+
+
+def test_validate_with_all_validators_fail():
+    """Validate should fail if all validators return False"""
+
+    def v1(value):
+        return False
+
+    def v2(value):
+        return False
+
+    option = Option(validators=[v1, v2])
+    assert option._validate() == (False, ["v1", "v2"])
+
+
+def test_validate_with_validators_fail():
+    """Validate should fail if a validator returns False"""
+
+    def v1(value):
+        return True
+
+    def v2(value):
+        return False
+
+    option = Option(validators=[v1, v2])
+    assert option._validate() == (False, ["v2"])

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -7,22 +7,22 @@ from elmo.conf.options import Option
 def test_default_constructor():
     """Should create a permissive config option"""
     option = Option()
-    assert option.read_only == False
-    assert option.required == False
-    assert option.allow_null == True
+    assert option.read_only is False
+    assert option.required is False
+    assert option.allow_null is True
     assert option.validators == []
 
 
 def test_invalid_required_default():
     """Should raise an exception if invalid configuration is used"""
     with pytest.raises(InvalidConfig):
-        option = Option(required=True)
+        Option(required=True)
 
 
 def test_valid_required_default():
     """Should accept required kwarg with a default"""
     option = Option(required=True, default="test")
-    assert option.required == True
+    assert option.required is True
     assert option.default == "test"
 
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,56 @@
+import pytest
+
+from elmo.conf.exceptions import ValidationError
+from elmo.conf.validators import not_null, is_https_url
+
+
+def test_not_null_boolean():
+    """Should succeed with a not None value"""
+    assert not_null(True) is True
+    assert not_null(False) is True
+
+
+def test_not_null_with_string():
+    """Should succeed with a not None value"""
+    assert not_null("test") is True
+
+
+def test_not_null_with_number():
+    """Should succeed with a not None value"""
+    assert not_null(0) is True
+    assert not_null(42) is True
+
+
+def test_not_null_with_false():
+    """Should fail with a None value"""
+    with pytest.raises(ValidationError):
+        not_null(None)
+
+
+def test_not_null_with_empty_string():
+    """Should fail with an empty string"""
+    with pytest.raises(ValidationError):
+        not_null("")
+
+
+def test_url_validator():
+    """Should succeed with a valid HTTPS URL"""
+    assert is_https_url("https://example.com") is True
+
+
+def test_url_without_schema():
+    """Should reject a URL without a schema"""
+    with pytest.raises(ValidationError):
+        is_https_url("example.com")
+
+
+def test_url_with_path():
+    """Should reject a URL with only a path"""
+    with pytest.raises(ValidationError):
+        is_https_url("/example.com")
+
+
+def test_url_wrong_values():
+    """Should reject a URL without HTTPS"""
+    with pytest.raises(ValidationError):
+        is_https_url("http://foo")

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,8 @@ envlist =
     py{37}
 
 [testenv]
+setenv =
+    PIPENV_VERBOSITY=-1
 deps = pipenv
 basepython =
     py37: python3.7
@@ -12,6 +14,8 @@ commands =
     pipenv run python -m pytest tests --cov=elmo -s
 
 [testenv:lint]
+setenv =
+    PIPENV_VERBOSITY=-1
 basepython =
     python3.7
 commands =


### PR DESCRIPTION
### Overview

Closes #17 

Adds a `conf` module to define application settings. Each setting is defined with an `Option`  class that includes built-in validators and is extendable to add more. `Option` initialization exposes the following kwargs:
* `default`: to define the default value
* `allow_null`: if `None` value is allowed or not
* `validators`: a list of functions that are executed to validate option's value

### Example
```python
from elmo.conf.config import BaseConfig

class Settings(BaseConfig):
    url = Option(default="http://example.com", allow_null=False)
    home = Option()
    dry_run = Option(validators=[is_boolean])

settings = Settings()
settings.is_valid()  # executes all options validators
```