### PR TITLE
Use `responses` to mock requests instead of using a testing router

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ flake8 = "*"
 elmo = {editable = true,path = "."}
 pytest-mock = "*"
 codecov = "*"
+responses = "*"
 
 [packages]
 requests = "*"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,115 +1,20 @@
 import pytest
-
-from requests import Response
+import responses
 
 from elmo.api.client import ElmoClient
+from elmo.api.router import Router
 
 
 @pytest.fixture
-def mock_client(mocker):
-    """Create an ElmoClient that mocks external calls based on the values
-    defined by the internal router. The mock tests the client internal logic
-    (i.e. retrieving an access token), but it doesn't take in account the
-    response from the server.
-
-    If the response changes, ``mockresponse`` must be updated.
-    """
+def client():
+    """Create an ElmoClient with a default base URL."""
     client = ElmoClient()
-
-    def mockresponse(endpoint, data=None):
-        response = Response()
-        if endpoint == client._router.auth:
-            if data.get("UserName") == data.get("Password") == "test":
-                # Correct credentials
-                response.status_code = 200
-                response._content = b"""<script type="text/javascript">
-                  var apiURL = 'https://example.com';
-                  var sessionId = '00000000-0000-0000-0000-000000000000';
-                  var canElevate = '1';
-                """
-            elif data.get("UserName") == data.get("Password") == "test-fail":
-                # Wrong credentials. Status Code is still 200 (API behavior)
-                response.status_code = 200
-                response._content = b""
-            else:
-                # Server Error
-                response.status_code = 500
-                response._context = b"Server error"
-        elif endpoint == client._router.lock:
-            if data.get("password") == data.get("sessionId") == "test":
-                # Correct credentials
-                response.status_code = 200
-                response._context = b"""[
-                    {
-                        "Poller": {"Poller": 1, "Panel": 1},
-                        "CommandId": 5,
-                        "Successful": True,
-                    }
-                ]"""
-            elif data.get("password") == data.get("sessionId") == "test-fail":
-                # Wrong credentials
-                response.status_code = 403
-                response._context = b"""[
-                    {
-                        "Poller": {"Poller": 1, "Panel": 1},
-                        "CommandId": 5,
-                        "Successful": False,
-                    }
-                ]"""
-            else:
-                # Server Error
-                response.status_code = 500
-                response._context = b"Server error"
-        elif endpoint == client._router.unlock:
-            if data.get("sessionId") == "test":
-                # Correct credentials
-                response.status_code = 200
-                response._context = b"""[
-                    {
-                        "Poller": {"Poller": 1, "Panel": 1},
-                        "CommandId": 5,
-                        "Successful": True,
-                    }
-                ]"""
-            elif data.get("sessionId") == "test-fail":
-                # Wrong credentials
-                response.status_code = 403
-                response._context = b"""[
-                    {
-                        "Poller": {"Poller": 1, "Panel": 1},
-                        "CommandId": 5,
-                        "Successful": False,
-                    }
-                ]"""
-            else:
-                # Server Error
-                response.status_code = 500
-                response._context = b"Server error"
-        elif endpoint == client._router.send_command:
-            if data.get("sessionId") == "test":
-                # Correct credentials
-                response.status_code = 200
-                response._context = b"""[
-                    {
-                        "CommandId": 1,
-                        "Successful": True,
-                    }
-                ]"""
-            elif data.get("sessionId") == "test-fail":
-                # Wrong credentials
-                response.status_code = 403
-                response._context = b"""[
-                    {
-                        "CommandId": 1,
-                        "Successful": False,
-                    }
-                ]"""
-            else:
-                # Server Error
-                response.status_code = 500
-                response._context = b"Server error"
-
-        return response
-
-    mocker.patch.object(client._session, "post", side_effect=mockresponse)
+    client._router = Router("https://example.com", "vendor")
     yield client
+
+
+@pytest.fixture
+def server():
+    """Create a `responses` mock."""
+    with responses.RequestsMock() as resp:
+        yield resp

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,164 +1,342 @@
 import pytest
+import responses
 
 from elmo.api.exceptions import APIException, PermissionDenied, LockNotAcquired
 
 
-def test_client_auth_success(mock_client):
+def test_client_auth_success(server, client):
     """Should authenticate with valid credentials."""
-    mock_client.auth("test", "test")
-    assert mock_client._session_id == "00000000-0000-0000-0000-000000000000"
+    html = """<script type="text/javascript">
+        var apiURL = 'https://example.com';
+        var sessionId = '00000000-0000-0000-0000-000000000000';
+        var canElevate = '1';
+    """
+    server.add(responses.POST, "https://example.com/vendor", body=html, status=200)
+
+    client.auth("test", "test")
+    assert client._session_id == "00000000-0000-0000-0000-000000000000"
+    assert len(server.calls) == 1
 
 
-def test_client_auth_failure(mock_client):
-    """Should raise an exception if credentials are not valid."""
+def test_client_auth_forbidden(server, client):
+    """Should raise an exception if credentials are not valid. Elmo
+    endpoint returns a 200 with a wrong authentication error.
+    """
+    server.add(
+        responses.POST,
+        "https://example.com/vendor",
+        body="Wrong authentication",
+        status=200,
+    )
+
     with pytest.raises(PermissionDenied):
-        mock_client.auth("test-fail", "test-fail")
+        client.auth("test", "test")
+    assert client._session_id is None
+    assert len(server.calls) == 1
 
 
-def test_client_auth_unknown_error(mock_client):
+def test_client_auth_unknown_error(server, client):
     """Should raise an exception if there is an unknown error."""
+    server.add(
+        responses.POST, "https://example.com/vendor", body="Server Error", status=500
+    )
+
     with pytest.raises(APIException):
-        mock_client.auth("unknown", "unknown")
+        client.auth("test", "test")
+    assert client._session_id is None
+    assert len(server.calls) == 1
 
 
-def test_client_lock(mock_client, mocker):
+def test_client_lock(server, client, mocker):
     """Should acquire a lock if credentials are properly provided."""
-    mocker.patch.object(mock_client, "unlock")
-    mock_client._session_id = "test"
-    with mock_client.lock("test"):
-        assert not mock_client._lock.acquire(False)
+    html = """[
+        {
+            "Poller": {"Poller": 1, "Panel": 1},
+            "CommandId": 5,
+            "Successful": True,
+        }
+    ]"""
+    server.add(
+        responses.POST, "https://example.com/api/panel/syncLogin", body=html, status=200
+    )
+    mocker.patch.object(client, "unlock")
+    client._session_id = "test"
+
+    with client.lock("test"):
+        assert not client._lock.acquire(False)
+    assert len(server.calls) == 1
 
 
-def test_client_lock_missing_code(mock_client, mocker):
-    """Should raise an Exception for unknown status code."""
-    mocker.patch.object(mock_client, "unlock")
-    mock_client._session_id = "test"
-    with pytest.raises(APIException):
-        with mock_client.lock(None):
-            pass
-
-
-def test_client_lock_forbidden(mock_client, mocker):
+def test_client_lock_forbidden(server, client, mocker):
     """Should raise an Exception if credentials are not correct."""
-    mocker.patch.object(mock_client, "unlock")
-    mock_client._session_id = "test-fail"
+    html = """[
+        {
+            "Poller": {"Poller": 1, "Panel": 1},
+            "CommandId": 5,
+            "Successful": False,
+        }
+    ]"""
+    server.add(
+        responses.POST, "https://example.com/api/panel/syncLogin", body=html, status=403
+    )
+    mocker.patch.object(client, "unlock")
+    client._session_id = "test"
+
     with pytest.raises(PermissionDenied):
-        with mock_client.lock("test-fail"):
+        with client.lock("test"):
             pass
+    assert len(server.calls) == 1
 
 
-def test_client_lock_calls_unlock(mock_client, mocker):
+def test_client_lock_unknown_error(server, client, mocker):
+    """Should raise an Exception for unknown status code."""
+    server.add(
+        responses.POST,
+        "https://example.com/api/panel/syncLogin",
+        body="Server Error",
+        status=500,
+    )
+
+    mocker.patch.object(client, "unlock")
+    client._session_id = "test"
+
+    with pytest.raises(APIException):
+        with client.lock(None):
+            pass
+    assert len(server.calls) == 1
+
+
+def test_client_lock_calls_unlock(server, client, mocker):
     """Should call unlock() when exiting from the context."""
-    mocker.patch.object(mock_client, "unlock")
-    mock_client._session_id = "test"
-    with mock_client.lock("test"):
+    server.add(responses.POST, "https://example.com/api/panel/syncLogin")
+    mocker.patch.object(client, "unlock")
+    client._session_id = "test"
+
+    with client.lock("test"):
         pass
-    assert mock_client.unlock.called is True
+    assert client.unlock.called is True
+    assert len(server.calls) == 1
 
 
-def test_client_unlock(mock_client):
+def test_client_unlock(server, client):
     """Should call the API and release the system lock."""
-    mock_client._session_id = "test"
-    mock_client._lock.acquire()
-    assert mock_client.unlock() is True
-    assert mock_client._session.post.called is True
-    assert mock_client._lock.acquire(False)
+    html = """[
+        {
+            "Poller": {"Poller": 1, "Panel": 1},
+            "CommandId": 5,
+            "Successful": True,
+        }
+    ]"""
+    server.add(
+        responses.POST,
+        "https://example.com/api/panel/syncLogout",
+        body=html,
+        status=200,
+    )
+    client._session_id = "test"
+    client._lock.acquire()
+
+    assert client.unlock() is True
+    assert client._lock.acquire(False)
+    assert len(server.calls) == 1
 
 
-def test_client_unlock_fails_missing_lock(mock_client):
+def test_client_unlock_fails_missing_lock(server, client):
     """unlock() should fail without calling the endpoint if Lock() has not been acquired."""
-    mock_client._session_id = "test"
+    client._session_id = "test"
+
     with pytest.raises(LockNotAcquired):
-        mock_client.unlock()
-    assert mock_client._session.post.called is False
-    assert mock_client._lock.acquire(False)
+        client.unlock()
+    assert client._lock.acquire(False)
+    assert len(server.calls) == 0
 
 
-def test_client_unlock_fails_wrong_credentials(mock_client):
+def test_client_unlock_fails_forbidden(server, client):
     """Should fail if wrong credentials are used."""
-    mock_client._session_id = "test-fail"
-    mock_client._lock.acquire()
+    html = """[
+        {
+            "Poller": {"Poller": 1, "Panel": 1},
+            "CommandId": 5,
+            "Successful": False,
+        }
+    ]"""
+    server.add(
+        responses.POST,
+        "https://example.com/api/panel/syncLogout",
+        body=html,
+        status=403,
+    )
+
+    client._session_id = "test"
+    client._lock.acquire()
+
     with pytest.raises(PermissionDenied):
-        mock_client.unlock()
-    assert mock_client._session.post.called is True
-    assert not mock_client._lock.acquire(False)
+        client.unlock()
+    assert not client._lock.acquire(False)
+    assert len(server.calls) == 1
 
 
-def test_client_unlock_fails_unexpected_error(mock_client):
+def test_client_unlock_fails_unexpected_error(server, client):
     """Should raise an error and keep the lock if the server has problems."""
-    mock_client._session_id = "unknown"
-    mock_client._lock.acquire()
+    html = """[
+        {
+            "Poller": {"Poller": 1, "Panel": 1},
+            "CommandId": 5,
+            "Successful": False,
+        }
+    ]"""
+    server.add(
+        responses.POST,
+        "https://example.com/api/panel/syncLogout",
+        body=html,
+        status=500,
+    )
+    client._session_id = "test"
+    client._lock.acquire()
+
     with pytest.raises(APIException):
-        mock_client.unlock()
-    assert mock_client._session.post.called is True
-    assert not mock_client._lock.acquire(False)
+        client.unlock()
+    assert not client._lock.acquire(False)
+    assert len(server.calls) == 1
 
 
-def test_client_arm(mock_client):
+def test_client_arm(server, client):
     """Should call the API and arm the system."""
-    mock_client._session_id = "test"
-    mock_client._lock.acquire()
-    assert mock_client.arm() is True
-    assert mock_client._session.post.called is True
+    html = """[
+        {
+            "Poller": {"Poller": 1, "Panel": 1},
+            "CommandId": 5,
+            "Successful": True,
+        }
+    ]"""
+    server.add(
+        responses.POST,
+        "https://example.com/api/panel/syncSendCommand",
+        body=html,
+        status=200,
+    )
+    client._session_id = "test"
+    client._lock.acquire()
+
+    assert client.arm() is True
+    assert len(server.calls) == 1
 
 
-def test_client_arm_fails_missing_lock(mock_client):
+def test_client_arm_fails_missing_lock(server, client):
     """arm() should fail without calling the endpoint if Lock() has not been acquired."""
-    mock_client._session_id = "test"
+    client._session_id = "test"
+
     with pytest.raises(LockNotAcquired):
-        mock_client.arm()
-    assert mock_client._session.post.called is False
-    assert mock_client._lock.acquire(False)
+        client.arm()
+    assert client._lock.acquire(False)
+    assert len(server.calls) == 0
 
 
-def test_client_arm_fails_missing_session(mock_client):
+def test_client_arm_fails_missing_session(server, client):
     """Should fail if a wrong access token is used."""
-    mock_client._session_id = "test-fail"
-    mock_client._lock.acquire()
+    html = """[
+        {
+            "Poller": {"Poller": 1, "Panel": 1},
+            "CommandId": 5,
+            "Successful": False,
+        }
+    ]"""
+    server.add(
+        responses.POST,
+        "https://example.com/api/panel/syncSendCommand",
+        body=html,
+        status=403,
+    )
+    client._session_id = "test"
+    client._lock.acquire()
+
     with pytest.raises(PermissionDenied):
-        mock_client.arm()
-    assert mock_client._session.post.called is True
+        client.arm()
+    assert len(server.calls) == 1
 
 
-def test_client_arm_fails_unknown_error(mock_client):
+def test_client_arm_fails_unknown_error(server, client):
     """Should fail if an unknown error happens."""
-    mock_client._session_id = "unknown"
-    mock_client._lock.acquire()
+    server.add(
+        responses.POST,
+        "https://example.com/api/panel/syncSendCommand",
+        body="Server Error",
+        status=500,
+    )
+    client._session_id = "test"
+    client._lock.acquire()
+
     with pytest.raises(APIException):
-        mock_client.arm()
-    assert mock_client._session.post.called is True
+        client.arm()
+    assert len(server.calls) == 1
 
 
-def test_client_disarm(mock_client):
+def test_client_disarm(server, client):
     """Should call the API and disarm the system."""
-    mock_client._session_id = "test"
-    mock_client._lock.acquire()
-    assert mock_client.disarm() is True
-    assert mock_client._session.post.called is True
+    html = """[
+        {
+            "Poller": {"Poller": 1, "Panel": 1},
+            "CommandId": 5,
+            "Successful": True,
+        }
+    ]"""
+    server.add(
+        responses.POST,
+        "https://example.com/api/panel/syncSendCommand",
+        body=html,
+        status=200,
+    )
+    client._session_id = "test"
+    client._lock.acquire()
+
+    assert client.disarm() is True
+    assert len(server.calls) == 1
 
 
-def test_client_disarm_fails_missing_lock(mock_client):
+def test_client_disarm_fails_missing_lock(server, client):
     """disarm() should fail without calling the endpoint if Lock() has not been acquired."""
-    mock_client._session_id = "test"
+    client._session_id = "test"
+
     with pytest.raises(LockNotAcquired):
-        mock_client.disarm()
-    assert mock_client._session.post.called is False
-    assert mock_client._lock.acquire(False)
+        client.disarm()
+    assert client._lock.acquire(False)
+    assert len(server.calls) == 0
 
 
-def test_client_disarm_fails_missing_session(mock_client):
+def test_client_disarm_fails_missing_session(server, client):
     """Should fail if a wrong access token is used."""
-    mock_client._session_id = "test-fail"
-    mock_client._lock.acquire()
+    html = """[
+        {
+            "Poller": {"Poller": 1, "Panel": 1},
+            "CommandId": 5,
+            "Successful": False,
+        }
+    ]"""
+    server.add(
+        responses.POST,
+        "https://example.com/api/panel/syncSendCommand",
+        body=html,
+        status=403,
+    )
+    client._session_id = "test"
+    client._lock.acquire()
+
     with pytest.raises(PermissionDenied):
-        mock_client.disarm()
-    assert mock_client._session.post.called is True
+        client.disarm()
+    assert len(server.calls) == 1
 
 
-def test_client_disarm_fails_unknown_error(mock_client):
+def test_client_disarm_fails_unknown_error(server, client):
     """Should fail if an unknown error happens."""
-    mock_client._session_id = "unknown"
-    mock_client._lock.acquire()
+    server.add(
+        responses.POST,
+        "https://example.com/api/panel/syncSendCommand",
+        body="Server Error",
+        status=500,
+    )
+    client._session_id = "unknown"
+    client._lock.acquire()
+
     with pytest.raises(APIException):
-        mock_client.disarm()
-    assert mock_client._session.post.called is True
+        client.disarm()
+    assert len(server.calls) == 1


### PR DESCRIPTION
### Overview

Instead of having a complicated `conftest.py` that has an internal router to handle different responses, the project now uses [responses](https://github.com/getsentry/responses).

* the change doesn't alter the test suite
* every test mocks only the endpoint the test is calling