### PR TITLE
Decouple ElmoClient from Settings

### DIFF
--- a/elmo/api/client.py
+++ b/elmo/api/client.py
@@ -7,7 +7,6 @@ from .router import Router
 from .exceptions import PermissionDenied, APIException
 from .decorators import require_session, require_lock
 
-from ..conf import settings
 from ..utils import parser
 
 
@@ -27,8 +26,8 @@ class ElmoClient(object):
             c.disarm()  # Disarm all alarms
     """
 
-    def __init__(self):
-        self._router = Router(settings.base_url, settings.vendor)
+    def __init__(self, base_url, vendor):
+        self._router = Router(base_url, vendor)
         self._session = Session()
         self._session_id = None
         self._lock = Lock()

--- a/elmo/conf.py
+++ b/elmo/conf.py
@@ -18,6 +18,3 @@ class Settings(BaseSettings):
         validators=[validators.is_https_url],
     )
     vendor = Option(default=os.getenv("ELMO_VENDOR"), allow_null=False)
-
-
-settings = Settings()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,14 +2,12 @@ import pytest
 import responses
 
 from elmo.api.client import ElmoClient
-from elmo.api.router import Router
 
 
 @pytest.fixture
 def client():
     """Create an ElmoClient with a default base URL."""
-    client = ElmoClient()
-    client._router = Router("https://example.com", "vendor")
+    client = ElmoClient("https://example.com", "vendor")
     yield client
 
 


### PR DESCRIPTION
### Overview

Decouple `ElmoClient` from `Settings`. Settings are now related to the base project (the web server / cloud function) that injects those values into the client.