### PR TITLE
[core/client] method auth() returns the access token

### DIFF
--- a/elmo/api/client.py
+++ b/elmo/api/client.py
@@ -41,6 +41,9 @@ class ElmoClient(object):
         Raises:
             PermissionDenied: if wrong credentials are used.
             APIException: if there is an error raised by the API (not 2xx response).
+        Returns:
+            The access token retrieved from the scraped page. The token is also
+            cached in the `ElmoClient` instance.
         """
         payload = {"UserName": username, "Password": password, "RememberMe": False}
         response = self._session.post(self._router.auth, data=payload)
@@ -53,6 +56,8 @@ class ElmoClient(object):
 
         if self._session_id is None:
             raise PermissionDenied("You do not have permission to perform this action.")
+
+        return self._session_id
 
     @contextmanager
     @require_session

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -13,7 +13,7 @@ def test_client_auth_success(server, client):
     """
     server.add(responses.POST, "https://example.com/vendor", body=html, status=200)
 
-    client.auth("test", "test")
+    assert client.auth("test", "test") == "00000000-0000-0000-0000-000000000000"
     assert client._session_id == "00000000-0000-0000-0000-000000000000"
     assert len(server.calls) == 1
 


### PR DESCRIPTION
### Overview

When calling `Elmoclient.auth(username, password)`, the access token is returned to the caller. The access token is still cached in `_session_id` attribute.