### PR TITLE
[core/client] add session_id to the ElmoClient initializer

### DIFF
--- a/elmo/api/client.py
+++ b/elmo/api/client.py
@@ -26,10 +26,10 @@ class ElmoClient(object):
             c.disarm()  # Disarm all alarms
     """
 
-    def __init__(self, base_url, vendor):
+    def __init__(self, base_url, vendor, session_id=None):
         self._router = Router(base_url, vendor)
         self._session = Session()
-        self._session_id = None
+        self._session_id = session_id
         self._lock = Lock()
 
     def auth(self, username, password):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,22 @@
 import pytest
 import responses
 
+from elmo.api.client import ElmoClient
 from elmo.api.exceptions import APIException, PermissionDenied, LockNotAcquired
+
+
+def test_client_constructor():
+    """Should build the client using the base URL and the vendor suffix."""
+    client = ElmoClient("https://example.com", "vendor")
+    assert client._router._base_url == "https://example.com"
+    assert client._router._vendor == "vendor"
+    assert client._session_id is None
+
+
+def test_client_constructor_with_session_id():
+    """Should build the client with a provided `session_id`."""
+    client = ElmoClient("https://example.com", "vendor", session_id="test")
+    assert client._session_id == "test"
 
 
 def test_client_auth_success(server, client):


### PR DESCRIPTION
### Overview

Closes #34 

Provides an extra `kwarg` to the `ElmoClient` constructor, so that it's possible:
```python
from elmo.api.client import ElmoClient

c = ElmoClient(session_id="test)
```