### PR TITLE
[core/client] leverage requests raise_for_status() instead of internal exceptions handling

### DIFF
--- a/elmo/api/exceptions.py
+++ b/elmo/api/exceptions.py
@@ -4,10 +4,7 @@ class APIException(Exception):
     default_message = "A server error occurred"
 
     def __init__(self, message=None):
-        if message is None:
-            message = self.default_message
-
-        self.message = message
+        self.message = message or self.default_message
 
     def __str__(self):
         return str(self.message)


### PR DESCRIPTION
### Overview

Closes #37 

Leverages requests `Response.raise_for_status()` call, so that it's not needed anymore to check the result and raise an internal exception. This removes all the duplication about error handling, and every `ElmoClient` method does only what it needs.