### PR TITLE
Add `check()` API to retrieve the status of the system

### DIFF
--- a/elmo/api/client.py
+++ b/elmo/api/client.py
@@ -167,7 +167,24 @@ class ElmoClient(object):
 
     @require_session
     def check(self):
-        """TODO"""
+        """Check the Elmo System to get the status of armed or disarmed areas, inputs
+        that are in alerted state or that are waiting. With this method you can check:
+            * The global status if any area is in alerted state
+            * The status for each area, if the alarm is armed or disarmed
+            * The status for each area, if the area is in alerted state
+
+        Raises:
+            HTTPError: if there is an error raised by the API (not 2xx response).
+        Returns:
+            A `dict` object that includes all the above information. The `dict` is in
+            the following format:
+            {
+                "areas_armed": [{"id": 0, "name": "Entryway"}, ...],
+                "areas_disarmed": [{"id": 1, "name": "Kitchen"}, ...],
+                "inputs_alerted": [{"id": 0, "name": "Door"}, ...],
+                "inputs_wait": [{"id": 1, "name": "Window"}, ...],
+            }
+        """
 
         # Area status
         response = self._session.post(

--- a/elmo/api/client.py
+++ b/elmo/api/client.py
@@ -151,3 +151,23 @@ class ElmoClient(object):
         response = self._session.post(self._router.send_command, data=payload)
         response.raise_for_status()
         return True
+
+    @require_session
+    def _get_items(self, route):
+        """Generic function that retrieves items from Elmo dashboard.
+
+        Raises:
+            PermissionDenied: if a wrong access token is used or expired.
+            APIException: if there is an error raised by the API (not 2xx response).
+        Returns:
+            A list of string of retrieve items, areas or inputs names.
+        """
+        response = self._session.get(route)
+        if response.status_code == 200:
+            return parser.get_listed_items(response.text)
+        elif response.status_code == 403:
+            raise PermissionDenied()
+        else:
+            raise APIException(
+                "Unexpected status code: {}".format(response.status_code)
+            )

--- a/elmo/api/client.py
+++ b/elmo/api/client.py
@@ -153,30 +153,23 @@ class ElmoClient(object):
         return True
 
     @require_session
-    def _get_items(self, route):
+    def _get_names(self, route):
         """Generic function that retrieves items from Elmo dashboard.
 
         Raises:
-            PermissionDenied: if a wrong access token is used or expired.
-            APIException: if there is an error raised by the API (not 2xx response).
+            HTTPError: if there is an error raised by the API (not 2xx response).
         Returns:
             A list of string of retrieve items, areas or inputs names.
         """
         response = self._session.get(route)
-        if response.status_code == 200:
-            return parser.get_listed_items(response.text)
-        elif response.status_code == 403:
-            raise PermissionDenied()
-        else:
-            raise APIException(
-                "Unexpected status code: {}".format(response.status_code)
-            )
+        response.raise_for_status()
+        return parser.get_listed_items(response.text)
 
     @require_session
     def check(self):
         """TODO: this is a meaty function. Refactor in small pieces."""
-        areas_names = self._get_items(self._router.areas_list)
-        inputs_names = self._get_items(self._router.inputs_list)
+        areas_names = self._get_names(self._router.areas_list)
+        inputs_names = self._get_names(self._router.inputs_list)
 
         # Retrieve Areas and Inputs status
         payload = {

--- a/elmo/api/router.py
+++ b/elmo/api/router.py
@@ -30,7 +30,7 @@ class Router(object):
     @property
     def areas_list(self):
         # Returns a HTML page that requires parsing
-        return "{}/Areas".format(self._base_url)
+        return "{}/{}/Areas".format(self._base_url, self._vendor)
 
     @property
     def inputs(self):
@@ -39,4 +39,4 @@ class Router(object):
     @property
     def inputs_list(self):
         # Returns a HTML page that requires parsing
-        return "{}/Inputs".format(self._base_url)
+        return "{}/{}/Inputs".format(self._base_url, self._vendor)

--- a/elmo/api/router.py
+++ b/elmo/api/router.py
@@ -22,3 +22,21 @@ class Router(object):
     @property
     def send_command(self):
         return "{}/api/panel/syncSendCommand".format(self._base_url)
+
+    @property
+    def areas(self):
+        return "{}/api/areas".format(self._base_url)
+
+    @property
+    def areas_list(self):
+        # Returns a HTML page that requires parsing
+        return "{}/Areas".format(self._base_url)
+
+    @property
+    def inputs(self):
+        return "{}/api/inputs".format(self._base_url)
+
+    @property
+    def inputs_list(self):
+        # Returns a HTML page that requires parsing
+        return "{}/Inputs".format(self._base_url)

--- a/elmo/utils/parser.py
+++ b/elmo/utils/parser.py
@@ -1,5 +1,7 @@
 from uuid import UUID
 
+from bs4 import BeautifulSoup
+
 
 def get_access_token(html):
     """Retrieve the access token from a HTML page.
@@ -20,3 +22,18 @@ def get_access_token(html):
         token = None
 
     return token
+
+
+def get_listed_items(html):
+    """Retrieve items listed inside a HTML Table object. This
+    function is used to extract Areas and Input names from a raw
+    HTML page.
+
+    Args:
+        html: the HTML body containing the access token
+    Returns:
+        A list with the associated names (if any)
+    """
+    tree = BeautifulSoup(html, "html.parser")
+    rows = tree.select("tbody > tr")
+    return [x.getText().split("\n")[1] for x in rows]

--- a/elmo/utils/response_helper.py
+++ b/elmo/utils/response_helper.py
@@ -1,0 +1,33 @@
+def slice_list(items, names, key):
+    """Slice `items` list into two lists, using the `key` argument to define which
+    item belongs to which list. `key` is used on each item and it must be a boolean value.
+    During the slice, `names` list values are merged so that every items will include
+    relevant data. An `Index` key is used to find the right name for the given `item`.
+
+    This function is a helper to reduce code duplication, and is not meant to be generic.
+
+    Args:
+        items: The list that is sliced into two lists.
+        names: The list that contains data that should be merged with `items`.
+        key: The key that is used to decide on which list `item` should be put. The
+            item is accesed as a dict, and the value must be a boolean.
+    Returns:
+        Two lists where the first list contains only items which key was `True`, while
+        the second one contains items which key was `False`.
+    """
+    list_active = []
+    list_not_active = []
+    for item in items:
+        try:
+            # Not all items may have a mapped name
+            name = names[item["Index"]]
+        except IndexError:
+            name = "Unknown"
+
+        entry = {"id": item["Id"], "name": name}
+        if item[key]:
+            list_active.append(entry)
+        else:
+            list_not_active.append(entry)
+
+    return list_active, list_not_active

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ VERSION = "0.1.0"
 
 # What packages are required for this module to be executed?
 REQUIRES_PYTHON = ">=3.5.0"
-REQUIRED = ["requests[security]"]
+REQUIRED = ["requests[security]", "beautifulsoup4"]
 
 # What packages are optional?
 EXTRAS = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,3 +97,13 @@ def inputs_html():
     </table>
 </div>
     """
+
+
+@pytest.fixture
+def areas_data():
+    return """[{"Active":true,"ActivePartial":false,"Max":false,"Activable":true,"ActivablePartial":false,"InUse":true,"Id":1,"Index":0,"Element":1,"CommandId":0,"InProgress":false},{"Active":false,"ActivePartial":false,"Max":false,"Activable":true,"ActivablePartial":false,"InUse":true,"Id":2,"Index":1,"Element":1,"CommandId":0,"InProgress":false}]"""
+
+
+@pytest.fixture
+def inputs_data():
+    return """[{"Alarm":false,"MemoryAlarm":false,"Excluded":false,"InUse":true,"IsVideo":false,"Id":1,"Index":0,"Element":1,"CommandId":0,"InProgress":false},{"Alarm":false,"MemoryAlarm":false,"Excluded":false,"InUse":true,"IsVideo":false,"Id":2,"Index":1,"Element":1,"CommandId":0,"InProgress":false}]"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,3 +16,84 @@ def server():
     """Create a `responses` mock."""
     with responses.RequestsMock() as resp:
         yield resp
+
+
+@pytest.fixture
+def areas_html():
+    """HTML raw page fixture for Areas dashboard."""
+    return """<div class="row output-table">
+    <table class="input-table footable" data-page-size="5">
+        <thead>
+            <tr>
+                <th class="area-first-column">
+                    <h2 data-areaindex="1" id="hAreaName_3">Home</h2>
+                </th>
+                <th class="center" data-hide="">Status
+                </th>
+                <th class="center" data-hide="phone">Activable
+                </th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr class="odd">
+                <td data-sectorindex="1" id="tdSectorName_0">Entryway</td>
+                <td class="center">
+                    <div><a class="status-armed sendcommand" data-commandtype="2" data-elementclass="9" data-index="1" href="javascript:void(0)" id="aArea_0"><i class="icn-status-armed"></i>Enabled</a></div>
+                </td>
+                <td class="center"><i class="icon-ok" id="iArmable_0"></i></td>
+            </tr>
+            <tr class="even">
+                <td data-sectorindex="2" id="tdSectorName_1">Corridor</td>
+                <td class="center">
+                    <div><a class="status-armed sendcommand" data-commandtype="2" data-elementclass="9" data-index="2" href="javascript:void(0)" id="aArea_1"><i class="icn-status-armed"></i>Enabled</a></div>
+                </td>
+                <td class="center"><i class="icon-ok" id="iArmable_1"></i></td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+    """
+
+
+@pytest.fixture
+def inputs_html():
+    """HTML raw page fixture for Inputs dashboard."""
+    return """<div class="row">
+    <table class="input-table footable" data-page-size="5" id="tblInputs">
+        <thead>
+            <tr>
+                <th>
+                    <h2>Input</h2>
+                </th>
+                <th class="center" data-hide="">Status
+                </th>
+                <th class="center" data-hide="phone">Memory
+                </th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr class="odd">
+                <td id="tdInput_0">Main door</td>
+                <td class="center">
+                    <div><a class="status-idle sendcommand" data-commandtype="2" data-elementclass="10" data-index="1" href="javascript:void(0)" id="aInput_0"><i class="icn-status-idle"></i>Wait</a></div>
+                </td>
+                <td class="center"><i class="icon-dash-gray" id="iMemoryAlarm_0"></i></td>
+            </tr>
+            <tr class="even">
+                <td id="tdInput_1">Window</td>
+                <td class="center">
+                    <div><a class="status-idle sendcommand" data-commandtype="2" data-elementclass="10" data-index="2" href="javascript:void(0)" id="aInput_1"><i class="icn-status-idle"></i>Wait</a></div>
+                </td>
+                <td class="center"><i class="icon-dash-gray" id="iMemoryAlarm_1"></i></td>
+            </tr>
+            <tr class="odd">
+                <td id="tdInput_2">Shade</td>
+                <td class="center">
+                    <div><a class="status-idle sendcommand" data-commandtype="2" data-elementclass="10" data-index="3" href="javascript:void(0)" id="aInput_2"><i class="icn-status-idle"></i>Wait</a></div>
+                </td>
+                <td class="center"><i class="icon-dash-gray" id="iMemoryAlarm_2"></i></td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+    """

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -366,7 +366,7 @@ def test_client_get_areas(server, client, areas_html):
         responses.GET, "https://example.com/vendor/Areas", body=areas_html, status=200,
     )
     client._session_id = "test"
-    areas_names = client._get_items(client._router.areas_list)
+    areas_names = client._get_names(client._router.areas_list)
     assert areas_names == ["Entryway", "Corridor"]
 
 
@@ -379,7 +379,7 @@ def test_client_get_inputs(server, client, inputs_html):
         status=200,
     )
     client._session_id = "test"
-    inputs_names = client._get_items(client._router.inputs_list)
+    inputs_names = client._get_names(client._router.inputs_list)
     assert inputs_names == ["Main door", "Window", "Shade"]
 
 
@@ -392,8 +392,8 @@ def test_client_get_items_unauthorized(server, client):
         status=403,
     )
     client._session_id = "test"
-    with pytest.raises(PermissionDenied):
-        client._get_items(client._router.areas_list)
+    with pytest.raises(HTTPError):
+        client._get_names(client._router.areas_list)
 
 
 def test_client_get_items_error(server, client):
@@ -405,5 +405,5 @@ def test_client_get_items_error(server, client):
         status=400,
     )
     client._session_id = "test"
-    with pytest.raises(APIException):
-        client._get_items(client._router.areas_list)
+    with pytest.raises(HTTPError):
+        client._get_names(client._router.areas_list)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-from elmo.utils.parser import get_access_token
+from elmo.utils.parser import get_access_token, get_listed_items
 
 
 def test_retrieve_access_token():
@@ -27,3 +27,86 @@ def test_retrieve_access_token_empty():
     """Should retrieve an access token from the given HTML page."""
     token = get_access_token("")
     assert token is None
+
+
+def test_retrieve_areas_names():
+    """Should retrieve Areas names from a raw HTML page."""
+    html = """<div class="row output-table">
+    <table class="input-table footable" data-page-size="5">
+        <thead>
+            <tr>
+                <th class="area-first-column">
+                    <h2 data-areaindex="1" id="hAreaName_3">Home</h2>
+                </th>
+                <th class="center" data-hide="">Status
+                </th>
+                <th class="center" data-hide="phone">Activable
+                </th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr class="odd">
+                <td data-sectorindex="1" id="tdSectorName_0">Entryway</td>
+                <td class="center">
+                    <div><a class="status-armed sendcommand" data-commandtype="2" data-elementclass="9" data-index="1" href="javascript:void(0)" id="aArea_0"><i class="icn-status-armed"></i>Enabled</a></div>
+                </td>
+                <td class="center"><i class="icon-ok" id="iArmable_0"></i></td>
+            </tr>
+            <tr class="even">
+                <td data-sectorindex="2" id="tdSectorName_1">Corridor</td>
+                <td class="center">
+                    <div><a class="status-armed sendcommand" data-commandtype="2" data-elementclass="9" data-index="2" href="javascript:void(0)" id="aArea_1"><i class="icn-status-armed"></i>Enabled</a></div>
+                </td>
+                <td class="center"><i class="icon-ok" id="iArmable_1"></i></td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+    """
+    items = get_listed_items(html)
+    assert items == ["Entryway", "Corridor"]
+
+
+def test_retrieve_inputs_names():
+    """Should retrieve Inputs names from a raw HTML page."""
+    html = """<div class="row">
+    <table class="input-table footable" data-page-size="5" id="tblInputs">
+        <thead>
+            <tr>
+                <th>
+                    <h2>Input</h2>
+                </th>
+                <th class="center" data-hide="">Status
+                </th>
+                <th class="center" data-hide="phone">Memory
+                </th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr class="odd">
+                <td id="tdInput_0">Main door</td>
+                <td class="center">
+                    <div><a class="status-idle sendcommand" data-commandtype="2" data-elementclass="10" data-index="1" href="javascript:void(0)" id="aInput_0"><i class="icn-status-idle"></i>Wait</a></div>
+                </td>
+                <td class="center"><i class="icon-dash-gray" id="iMemoryAlarm_0"></i></td>
+            </tr>
+            <tr class="even">
+                <td id="tdInput_1">Window</td>
+                <td class="center">
+                    <div><a class="status-idle sendcommand" data-commandtype="2" data-elementclass="10" data-index="2" href="javascript:void(0)" id="aInput_1"><i class="icn-status-idle"></i>Wait</a></div>
+                </td>
+                <td class="center"><i class="icon-dash-gray" id="iMemoryAlarm_1"></i></td>
+            </tr>
+            <tr class="odd">
+                <td id="tdInput_2">Shade</td>
+                <td class="center">
+                    <div><a class="status-idle sendcommand" data-commandtype="2" data-elementclass="10" data-index="3" href="javascript:void(0)" id="aInput_2"><i class="icn-status-idle"></i>Wait</a></div>
+                </td>
+                <td class="center"><i class="icon-dash-gray" id="iMemoryAlarm_2"></i></td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+    """
+    items = get_listed_items(html)
+    assert items == ["Main door", "Window", "Shade"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,84 +29,13 @@ def test_retrieve_access_token_empty():
     assert token is None
 
 
-def test_retrieve_areas_names():
+def test_retrieve_areas_names(areas_html):
     """Should retrieve Areas names from a raw HTML page."""
-    html = """<div class="row output-table">
-    <table class="input-table footable" data-page-size="5">
-        <thead>
-            <tr>
-                <th class="area-first-column">
-                    <h2 data-areaindex="1" id="hAreaName_3">Home</h2>
-                </th>
-                <th class="center" data-hide="">Status
-                </th>
-                <th class="center" data-hide="phone">Activable
-                </th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr class="odd">
-                <td data-sectorindex="1" id="tdSectorName_0">Entryway</td>
-                <td class="center">
-                    <div><a class="status-armed sendcommand" data-commandtype="2" data-elementclass="9" data-index="1" href="javascript:void(0)" id="aArea_0"><i class="icn-status-armed"></i>Enabled</a></div>
-                </td>
-                <td class="center"><i class="icon-ok" id="iArmable_0"></i></td>
-            </tr>
-            <tr class="even">
-                <td data-sectorindex="2" id="tdSectorName_1">Corridor</td>
-                <td class="center">
-                    <div><a class="status-armed sendcommand" data-commandtype="2" data-elementclass="9" data-index="2" href="javascript:void(0)" id="aArea_1"><i class="icn-status-armed"></i>Enabled</a></div>
-                </td>
-                <td class="center"><i class="icon-ok" id="iArmable_1"></i></td>
-            </tr>
-        </tbody>
-    </table>
-</div>
-    """
-    items = get_listed_items(html)
+    items = get_listed_items(areas_html)
     assert items == ["Entryway", "Corridor"]
 
 
-def test_retrieve_inputs_names():
+def test_retrieve_inputs_names(inputs_html):
     """Should retrieve Inputs names from a raw HTML page."""
-    html = """<div class="row">
-    <table class="input-table footable" data-page-size="5" id="tblInputs">
-        <thead>
-            <tr>
-                <th>
-                    <h2>Input</h2>
-                </th>
-                <th class="center" data-hide="">Status
-                </th>
-                <th class="center" data-hide="phone">Memory
-                </th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr class="odd">
-                <td id="tdInput_0">Main door</td>
-                <td class="center">
-                    <div><a class="status-idle sendcommand" data-commandtype="2" data-elementclass="10" data-index="1" href="javascript:void(0)" id="aInput_0"><i class="icn-status-idle"></i>Wait</a></div>
-                </td>
-                <td class="center"><i class="icon-dash-gray" id="iMemoryAlarm_0"></i></td>
-            </tr>
-            <tr class="even">
-                <td id="tdInput_1">Window</td>
-                <td class="center">
-                    <div><a class="status-idle sendcommand" data-commandtype="2" data-elementclass="10" data-index="2" href="javascript:void(0)" id="aInput_1"><i class="icn-status-idle"></i>Wait</a></div>
-                </td>
-                <td class="center"><i class="icon-dash-gray" id="iMemoryAlarm_1"></i></td>
-            </tr>
-            <tr class="odd">
-                <td id="tdInput_2">Shade</td>
-                <td class="center">
-                    <div><a class="status-idle sendcommand" data-commandtype="2" data-elementclass="10" data-index="3" href="javascript:void(0)" id="aInput_2"><i class="icn-status-idle"></i>Wait</a></div>
-                </td>
-                <td class="center"><i class="icon-dash-gray" id="iMemoryAlarm_2"></i></td>
-            </tr>
-        </tbody>
-    </table>
-</div>
-    """
-    items = get_listed_items(html)
+    items = get_listed_items(inputs_html)
     assert items == ["Main door", "Window", "Shade"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 from elmo.utils.parser import get_access_token, get_listed_items
+from elmo.utils.response_helper import slice_list
 
 
 def test_retrieve_access_token():
@@ -39,3 +40,115 @@ def test_retrieve_inputs_names(inputs_html):
     """Should retrieve Inputs names from a raw HTML page."""
     items = get_listed_items(inputs_html)
     assert items == ["Main door", "Window", "Shade"]
+
+
+def test_slice_areas():
+    """Should slice properly an Area list."""
+    items = [
+        {
+            "Active": True,
+            "ActivePartial": False,
+            "Max": False,
+            "Activable": True,
+            "ActivablePartial": False,
+            "InUse": True,
+            "Id": 1,
+            "Index": 0,
+            "Element": 1,
+            "CommandId": 0,
+            "InProgress": False,
+        },
+        {
+            "Active": False,
+            "ActivePartial": False,
+            "Max": False,
+            "Activable": True,
+            "ActivablePartial": False,
+            "InUse": True,
+            "Id": 2,
+            "Index": 1,
+            "Element": 1,
+            "CommandId": 0,
+            "InProgress": False,
+        },
+    ]
+    names = ["Entryway", "Corridor"]
+    areas_active, areas_inactive = slice_list(items, names, "Active")
+    assert len(areas_active) == 1
+    assert len(areas_inactive) == 1
+    assert areas_active[0] == {"id": 1, "name": "Entryway"}
+    assert areas_inactive[0] == {"id": 2, "name": "Corridor"}
+
+
+def test_slice_inputs():
+    """Should slice properly an Input list."""
+    items = [
+        {
+            "Alarm": True,
+            "MemoryAlarm": False,
+            "Excluded": False,
+            "InUse": True,
+            "IsVideo": False,
+            "Id": 1,
+            "Index": 0,
+            "Element": 1,
+            "CommandId": 0,
+            "InProgress": False,
+        },
+        {
+            "Alarm": False,
+            "MemoryAlarm": False,
+            "Excluded": False,
+            "InUse": True,
+            "IsVideo": False,
+            "Id": 2,
+            "Index": 1,
+            "Element": 1,
+            "CommandId": 0,
+            "InProgress": False,
+        },
+    ]
+    names = ["Door", "Window"]
+    inputs_alerted, inputs_wait = slice_list(items, names, "Alarm")
+    assert len(inputs_alerted) == 1
+    assert len(inputs_wait) == 1
+    assert inputs_alerted[0] == {"id": 1, "name": "Door"}
+    assert inputs_wait[0] == {"id": 2, "name": "Window"}
+
+
+def test_slice_not_enough_names():
+    """Should slice properly an Area list, even if the names list is shorter."""
+    items = [
+        {
+            "Active": True,
+            "ActivePartial": False,
+            "Max": False,
+            "Activable": True,
+            "ActivablePartial": False,
+            "InUse": True,
+            "Id": 1,
+            "Index": 0,
+            "Element": 1,
+            "CommandId": 0,
+            "InProgress": False,
+        },
+        {
+            "Active": False,
+            "ActivePartial": False,
+            "Max": False,
+            "Activable": True,
+            "ActivablePartial": False,
+            "InUse": True,
+            "Id": 2,
+            "Index": 1,
+            "Element": 1,
+            "CommandId": 0,
+            "InProgress": False,
+        },
+    ]
+    names = ["Entryway"]
+    areas_active, areas_inactive = slice_list(items, names, "Active")
+    assert len(areas_active) == 1
+    assert len(areas_inactive) == 1
+    assert areas_active[0] == {"id": 1, "name": "Entryway"}
+    assert areas_inactive[0] == {"id": 2, "name": "Unknown"}

--- a/tox.ini
+++ b/tox.ini
@@ -25,4 +25,6 @@ commands =
 
 [flake8]
 max-line-length = 120
-exclude = .tox
+exclude =
+    .tox
+    conftest.py  # Contains fixtures


### PR DESCRIPTION
### Overview

Closes #36 

Adds a new public method to `ElmoClient` to make calls to multiple pages and endpoints to retrieve the global status of the system. It retrieves:
* Armed/Disarmed areas: https://connect.elmospa.com/api/areas | POST | sessionId
* Inputs status: https://connect.elmospa.com/api/inputs | POST | sessionId
* Area names: https://connect.elmospa.com/vendor/Areas | GET | only cookies
* Entries names: https://connect.elmospa.com/vendor/Inputs | GET | only cookies

Calling the method returns a Python `dict` with the following data:
```python
{
  "areas_armed": [{"id": 0, "name": "Entryway"}, ...],
  "areas_disarmed": [{"id": 1, "name": "Kitchen"}, ...],
  "inputs_alerted": [{"id": 0, "name": "Door"}, ...],
  "inputs_wait": [{"id": 1, "name": "Window"}, ...],
}

# Check if any system input is in alerted state (so it will be excluded when the Alarm is ON)
assert len(status["inputs_alerted"]) == 0

# The Alarm is OFF
assert len(status["areas_armed"]) == 0

# The Alarm is ON
assert len(status["areas_armed"]) > 0
```