### PR TITLE
Extend Arm() and Disarm() to enable/disable one or multiple sectors

### DIFF
--- a/elmo/api/client.py
+++ b/elmo/api/client.py
@@ -152,6 +152,55 @@ class ElmoClient(object):
         response.raise_for_status()
         return True
 
+
+    @require_session
+    @require_lock
+    def arm_sector(self, sector_number):
+        """Arm selected sector without any activation delay. This API works only
+        if a system lock has been obtained, otherwise the action ends with a failure.
+        Note: API subject to changes when more configurations are allowed, such as
+        enabling only some alerts.
+
+        Raises:
+            HTTPError: if there is an error raised by the API (not 2xx response).
+        Returns:
+            A boolean if the sector has been armed correctly.
+        """
+        payload = {
+            "CommandType": 1,
+            "ElementsClass": 9,
+            "ElementsIndexes": sector_number,
+            "sessionId": self._session_id,
+        }
+        response = self._session.post(self._router.send_command, data=payload)
+        response.raise_for_status()
+        return True
+
+
+    @require_session
+    @require_lock
+    def disarm_sector(self, sector_number):
+        """Deactivate selected sector alarm. This API works only if a system lock has been
+        obtained, otherwise the action ends with a failure.
+        Note: API subject to changes when more configurations are allowed, such as
+        enabling only some alerts.
+
+        Raises:
+            HTTPError: if there is an error raised by the API (not 2xx response).
+        Returns:
+            A boolean if the sector has been disarmed correctly.
+        """
+        payload = {
+            "CommandType": 2,
+            "ElementsClass": 9,
+            "ElementsIndexes": sector_number,
+            "sessionId": self._session_id,
+        }
+        response = self._session.post(self._router.send_command, data=payload)
+        response.raise_for_status()
+        return True
+
+
     @require_session
     def _get_names(self, route):
         """Generic function that retrieves items from Elmo dashboard.

--- a/elmo/api/client.py
+++ b/elmo/api/client.py
@@ -108,98 +108,103 @@ class ElmoClient(object):
 
     @require_session
     @require_lock
-    def arm(self):
-        """Arm all system alarms without any activation delay. This API works only
+    def arm(self, sectors=None):
+        """Arm system alarms without any activation delay. This API works only
         if a system lock has been obtained, otherwise the action ends with a failure.
-        Note: API subject to changes when more configurations are allowed, such as
-        enabling only some alerts.
+        It is possible to enable ALL sectors, or provide a list of sectors such as:
 
+            client.arm()        # Arms all sectors
+            client.arm([3, 4])  # Arms only sectors 3 and 4
+
+        Args:
+            sector: (optional) list of sectors that must be armed. If the variable is
+            empty, ALL is assumed and the entire system is armed. If multiple items
+            are in the list, multiple requests are sent to arm given sectors.
         Raises:
             HTTPError: if there is an error raised by the API (not 2xx response).
         Returns:
             A boolean if the system has been armed correctly.
         """
-        payload = {
-            "CommandType": 1,
-            "ElementsClass": 1,
-            "ElementsIndexes": 1,
-            "sessionId": self._session_id,
-        }
-        response = self._session.post(self._router.send_command, data=payload)
-        response.raise_for_status()
+        payloads = []
+        sectors = sectors or []
+
+        if sectors:
+            # Arm only selected sectors
+            for sector in sectors:
+                payloads.append(
+                    {
+                        "CommandType": 1,
+                        "ElementsClass": 9,
+                        "ElementsIndexes": sector,
+                        "sessionId": self._session_id,
+                    }
+                )
+        else:
+            # Arm ALL sectors
+            payloads = [
+                {
+                    "CommandType": 1,
+                    "ElementsClass": 1,
+                    "ElementsIndexes": 1,
+                    "sessionId": self._session_id,
+                }
+            ]
+
+        # Arming multiple sectors requires multiple requests
+        for payload in payloads:
+            response = self._session.post(self._router.send_command, data=payload)
+            response.raise_for_status()
         return True
 
     @require_session
     @require_lock
-    def disarm(self):
-        """Deactivate all system alarms. This API works only if a system lock has been
+    def disarm(self, sectors=None):
+        """Disarm system alarms. This API works only if a system lock has been
         obtained, otherwise the action ends with a failure.
-        Note: API subject to changes when more configurations are allowed, such as
-        enabling only some alerts.
+        It is possible to disable ALL sectors, or provide a list of sectors such as:
 
+            client.disarm()     # Disarms all sectors
+            client.disarm([3])  # Disarms only sector 3
+
+        Args:
+            sector: (optional) list of sectors that must be disarmed. If the variable is
+            empty, ALL is assumed and the entire system is disarmed. If multiple items
+            are in the list, multiple requests are sent to disarm given sectors.
         Raises:
             HTTPError: if there is an error raised by the API (not 2xx response).
         Returns:
             A boolean if the system has been disarmed correctly.
         """
-        payload = {
-            "CommandType": 2,
-            "ElementsClass": 1,
-            "ElementsIndexes": 1,
-            "sessionId": self._session_id,
-        }
-        response = self._session.post(self._router.send_command, data=payload)
-        response.raise_for_status()
+        payloads = []
+        sectors = sectors or []
+
+        if sectors:
+            # Disarm only selected sectors
+            for sector in sectors:
+                payloads.append(
+                    {
+                        "CommandType": 2,
+                        "ElementsClass": 9,
+                        "ElementsIndexes": sector,
+                        "sessionId": self._session_id,
+                    }
+                )
+        else:
+            # Disarm ALL sectors
+            payloads = [
+                {
+                    "CommandType": 2,
+                    "ElementsClass": 1,
+                    "ElementsIndexes": 1,
+                    "sessionId": self._session_id,
+                }
+            ]
+
+        # Disarming multiple sectors requires multiple requests
+        for payload in payloads:
+            response = self._session.post(self._router.send_command, data=payload)
+            response.raise_for_status()
         return True
-
-
-    @require_session
-    @require_lock
-    def arm_sector(self, sector_number):
-        """Arm selected sector without any activation delay. This API works only
-        if a system lock has been obtained, otherwise the action ends with a failure.
-        Note: API subject to changes when more configurations are allowed, such as
-        enabling only some alerts.
-
-        Raises:
-            HTTPError: if there is an error raised by the API (not 2xx response).
-        Returns:
-            A boolean if the sector has been armed correctly.
-        """
-        payload = {
-            "CommandType": 1,
-            "ElementsClass": 9,
-            "ElementsIndexes": sector_number,
-            "sessionId": self._session_id,
-        }
-        response = self._session.post(self._router.send_command, data=payload)
-        response.raise_for_status()
-        return True
-
-
-    @require_session
-    @require_lock
-    def disarm_sector(self, sector_number):
-        """Deactivate selected sector alarm. This API works only if a system lock has been
-        obtained, otherwise the action ends with a failure.
-        Note: API subject to changes when more configurations are allowed, such as
-        enabling only some alerts.
-
-        Raises:
-            HTTPError: if there is an error raised by the API (not 2xx response).
-        Returns:
-            A boolean if the sector has been disarmed correctly.
-        """
-        payload = {
-            "CommandType": 2,
-            "ElementsClass": 9,
-            "ElementsIndexes": sector_number,
-            "sessionId": self._session_id,
-        }
-        response = self._session.post(self._router.send_command, data=payload)
-        response.raise_for_status()
-        return True
-
 
     @require_session
     def _get_names(self, route):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -238,6 +238,43 @@ def test_client_arm(server, client):
 
     assert client.arm() is True
     assert len(server.calls) == 1
+    body = server.calls[0].request.body.split("&")
+    assert "CommandType=1" in body
+    assert "ElementsClass=1" in body
+    assert "ElementsIndexes=1" in body
+    assert "sessionId=test" in body
+
+
+def test_client_arm_sectors(server, client):
+    """Should call the API and arm only the given sectors."""
+    html = """[
+        {
+            "Poller": {"Poller": 1, "Panel": 1},
+            "CommandId": 5,
+            "Successful": True,
+        }
+    ]"""
+    server.add(
+        responses.POST,
+        "https://example.com/api/panel/syncSendCommand",
+        body=html,
+        status=200,
+    )
+    client._session_id = "test"
+    client._lock.acquire()
+
+    assert client.arm([3, 4]) is True
+    assert len(server.calls) == 2
+    body = server.calls[0].request.body.split("&")
+    assert "CommandType=1" in body
+    assert "ElementsClass=9" in body
+    assert "ElementsIndexes=3" in body
+    assert "sessionId=test" in body
+    body = server.calls[1].request.body.split("&")
+    assert "CommandType=1" in body
+    assert "ElementsClass=9" in body
+    assert "ElementsIndexes=4" in body
+    assert "sessionId=test" in body
 
 
 def test_client_arm_fails_missing_lock(server, client):
@@ -309,6 +346,43 @@ def test_client_disarm(server, client):
 
     assert client.disarm() is True
     assert len(server.calls) == 1
+    body = server.calls[0].request.body.split("&")
+    assert "CommandType=2" in body
+    assert "ElementsClass=1" in body
+    assert "ElementsIndexes=1" in body
+    assert "sessionId=test" in body
+
+
+def test_client_disarm_sectors(server, client):
+    """Should call the API and disarm only the given sectors."""
+    html = """[
+        {
+            "Poller": {"Poller": 1, "Panel": 1},
+            "CommandId": 5,
+            "Successful": True,
+        }
+    ]"""
+    server.add(
+        responses.POST,
+        "https://example.com/api/panel/syncSendCommand",
+        body=html,
+        status=200,
+    )
+    client._session_id = "test"
+    client._lock.acquire()
+
+    assert client.disarm([3, 4]) is True
+    assert len(server.calls) == 2
+    body = server.calls[0].request.body.split("&")
+    assert "CommandType=2" in body
+    assert "ElementsClass=9" in body
+    assert "ElementsIndexes=3" in body
+    assert "sessionId=test" in body
+    body = server.calls[1].request.body.split("&")
+    assert "CommandType=2" in body
+    assert "ElementsClass=9" in body
+    assert "ElementsIndexes=4" in body
+    assert "sessionId=test" in body
 
 
 def test_client_disarm_fails_missing_lock(server, client):


### PR DESCRIPTION
### Overview

Follow-up of #44 

Extends `arm()` and `disarm()` public APIs, so that one or multiple sectors can be armed/disarmed. The API change is backward compatible because `sectors` is an optional kwarg.

### Usage
```python
client.arm()        # Arm all sectors
client.arm([3, 4])  # Arm only sectors 3 and 4
client.disarm()     # Disarm all sectors
client.disarm([3])  # Disarm only sector 3
```