### PR TITLE
Use Authentication API instead of scraping the SessionID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ venv.bak/
 .mypy_cache/
 
 main.py
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -104,5 +104,5 @@ venv.bak/
 # mypy
 .mypy_cache/
 
-main.py
+# IDEs
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,5 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+main.py

--- a/elmo/api/client.py
+++ b/elmo/api/client.py
@@ -53,6 +53,10 @@ class ElmoClient(object):
         response.raise_for_status()
 
         self._session_id = parser.get_access_token(response.text)
+
+        self._api_url = parser.get_api_url(response.text)
+        self._router._base_url = self._api_url
+        
         if self._session_id is None:
             raise PermissionDenied("Incorrect authentication credentials")
 

--- a/elmo/api/client.py
+++ b/elmo/api/client.py
@@ -27,37 +27,47 @@ class ElmoClient(object):
     """
 
     def __init__(self, base_url, vendor, session_id=None):
-        self._router = Router(base_url, vendor)
+        self._router = Router(base_url)
+        self._vendor = vendor
         self._session = Session()
         self._session_id = session_id
         self._lock = Lock()
+        self._strings = None
 
     def auth(self, username, password):
         """Authenticate the client and retrieves the access token. This API uses
-        a standard authentication form, so even if the authentication fails, a
-        2xx status code is returned. In that case, the `session_id` is validated
-        to see if the call was a success.
-
+        the authentication API. 
         Args:
             username: the Username used for the authentication.
             password: the Password used for the authentication.
         Raises:
-            PermissionDenied: if wrong credentials are used.
             HTTPError: if there is an error raised by the API (not 2xx response).
         Returns:
-            The access token retrieved from the scraped page. The token is also
+            The access token retrieved from the API. The token is also
             cached in the `ElmoClient` instance.
         """
-        payload = {"UserName": username, "Password": password, "RememberMe": False}
-        response = self._session.post(self._router.auth, data=payload)
+        payload = {"username": username, "password": password, "domain": self._vendor}
+        response = self._session.get(self._router.auth, params=payload)
         response.raise_for_status()
 
-        self._session_id = parser.get_access_token(response.text)
+        data = response.json()
+        self._session_id = data["SessionId"]
 
-        if self._session_id is None:
-            raise PermissionDenied("Incorrect authentication credentials")
+        if data["Redirect"]:
+            self._router = Router(data["RedirectTo"])
+            self._session_id = self.auth(username, password)
+            return self._session_id
 
         return self._session_id
+    
+    @require_session
+    def _update_strings(self):
+        payload = {"sessionId": self._session_id}
+
+        response = self._session.post(self._router.strings, data=payload)
+        response.raise_for_status()
+
+        self._strings = response.json()
 
     @contextmanager
     @require_session
@@ -208,7 +218,7 @@ class ElmoClient(object):
         return True
 
     @require_session
-    def _get_names(self, route):
+    def _get_names(self, element, class_):
         """Generic function that retrieves items from Elmo dashboard.
 
         Raises:
@@ -216,9 +226,17 @@ class ElmoClient(object):
         Returns:
             A list of strings (names) for areas or system inputs.
         """
-        response = self._session.get(route)
-        response.raise_for_status()
-        return parser.get_listed_items(response.text)
+        index = element["Index"]
+
+        name = next(
+            filter(
+                lambda x: x["Class"] == class_ and x["Index"] == index, self._strings
+            ),
+            None,
+        )["Description"]
+
+        element["Name"] = name
+        return element
 
     @require_session
     def check(self):
@@ -240,29 +258,42 @@ class ElmoClient(object):
                 "inputs_wait": [{"id": 1, "name": "Window"}, ...],
             }
         """
+        # Retrieves strings if not present
+        if not self._strings:
+            self._update_strings()
 
-        # Area status
-        response = self._session.post(
-            self._router.areas, data={"sessionId": self._session_id}
-        )
+        payload = {"sessionId": self._session_id}
 
+        # Retrieve areas
+        response = self._session.post(self._router.areas, data=payload)
         response.raise_for_status()
+
         areas = response.json()
-        areas_names = self._get_names(self._router.areas_list)
-        areas_armed, areas_disarmed = response_helper.slice_list(
-            areas, areas_names, "Active"
-        )
+        areas = list(filter(lambda area: area["InUse"], areas))
+        areas = list(map(lambda x: self._get_names(x, 9), areas))
 
-        # System Input status
-        response = self._session.post(
-            self._router.inputs, data={"sessionId": self._session_id}
-        )
+        areas_armed = list(filter(lambda area: area['Active'], areas))
+        areas_disarmed = list(filter(lambda area: not area['Active'], areas))
+
+        # Retrieve inputs
+        response = self._session.post(self._router.inputs, data=payload)
         response.raise_for_status()
+
         inputs = response.json()
-        inputs_names = self._get_names(self._router.inputs_list)
-        inputs_alerted, inputs_wait = response_helper.slice_list(
-            inputs, inputs_names, "Alarm"
-        )
+        inputs = list(filter(lambda input_: input_["InUse"], inputs))
+        inputs = list(map(lambda x: self._get_names(x, 10), inputs))
+
+        inputs_alerted = list(filter(lambda input_: input_["Alarm"], inputs))
+        inputs_wait = list(filter(lambda input_: not input_["Alarm"], inputs))
+
+        def set_output_dict(item):
+            entry = {"id": item["Id"], "index": item["Index"], "element": item["Element"], "name": item["Name"]}
+            return entry
+        
+        areas_armed = list(map(lambda x: set_output_dict(x), areas_armed))
+        areas_disarmed = list(map(lambda x: set_output_dict(x), areas_disarmed))
+        inputs_alerted = list(map(lambda x: set_output_dict(x), inputs_alerted))
+        inputs_wait = list(map(lambda x: set_output_dict(x), inputs_wait))
 
         return {
             "areas_armed": areas_armed,

--- a/elmo/api/client.py
+++ b/elmo/api/client.py
@@ -4,7 +4,6 @@ from contextlib import contextmanager
 from requests import Session
 
 from .router import Router
-from .exceptions import PermissionDenied
 from .decorators import require_session, require_lock
 
 from ..utils import parser, response_helper

--- a/elmo/api/client.py
+++ b/elmo/api/client.py
@@ -53,10 +53,8 @@ class ElmoClient(object):
         response.raise_for_status()
 
         self._session_id = parser.get_access_token(response.text)
+        self._router._api_url = parser.get_api_url(response.text)
 
-        self._api_url = parser.get_api_url(response.text)
-        self._router._base_url = self._api_url
-        
         if self._session_id is None:
             raise PermissionDenied("Incorrect authentication credentials")
 
@@ -248,6 +246,7 @@ class ElmoClient(object):
         response = self._session.post(
             self._router.areas, data={"sessionId": self._session_id}
         )
+  
         response.raise_for_status()
         areas = response.json()
         areas_names = self._get_names(self._router.areas_list)

--- a/elmo/api/client.py
+++ b/elmo/api/client.py
@@ -53,7 +53,6 @@ class ElmoClient(object):
         response.raise_for_status()
 
         self._session_id = parser.get_access_token(response.text)
-        self._router._api_url = parser.get_api_url(response.text)
 
         if self._session_id is None:
             raise PermissionDenied("Incorrect authentication credentials")
@@ -246,7 +245,7 @@ class ElmoClient(object):
         response = self._session.post(
             self._router.areas, data={"sessionId": self._session_id}
         )
-  
+
         response.raise_for_status()
         areas = response.json()
         areas_names = self._get_names(self._router.areas_list)

--- a/elmo/api/router.py
+++ b/elmo/api/router.py
@@ -3,16 +3,13 @@ class Router(object):
     grouped by action type.
     """
 
-    def __init__(self, base_url):
+    def __init__(self, base_url, vendor):
+        self._vendor = vendor
         self._base_url = base_url
 
     @property
     def auth(self):
         return "{}/api/login".format(self._base_url)
-
-    @property
-    def strings(self):
-        return "{}/api/strings".format(self._base_url)
 
     @property
     def lock(self):
@@ -31,5 +28,15 @@ class Router(object):
         return "{}/api/areas".format(self._base_url)
 
     @property
+    def areas_list(self):
+        # Returns a HTML page that requires parsing
+        return "{}/{}/Areas".format(self._base_url, self._vendor)
+
+    @property
     def inputs(self):
         return "{}/api/inputs".format(self._base_url)
+
+    @property
+    def inputs_list(self):
+        # Returns a HTML page that requires parsing
+        return "{}/{}/Inputs".format(self._base_url, self._vendor)

--- a/elmo/api/router.py
+++ b/elmo/api/router.py
@@ -13,19 +13,19 @@ class Router(object):
 
     @property
     def lock(self):
-        return "{}/api/panel/syncLogin".format(self._api_url)
+        return "{}/api/panel/syncLogin".format(self._base_url)
 
     @property
     def unlock(self):
-        return "{}/api/panel/syncLogout".format(self._api_url)
+        return "{}/api/panel/syncLogout".format(self._base_url)
 
     @property
     def send_command(self):
-        return "{}/api/panel/syncSendCommand".format(self._api_url)
+        return "{}/api/panel/syncSendCommand".format(self._base_url)
 
     @property
     def areas(self):
-        return "{}/api/areas".format(self._api_url)
+        return "{}/api/areas".format(self._base_url)
 
     @property
     def areas_list(self):
@@ -34,7 +34,7 @@ class Router(object):
 
     @property
     def inputs(self):
-        return "{}/api/inputs".format(self._api_url)
+        return "{}/api/inputs".format(self._base_url)
 
     @property
     def inputs_list(self):

--- a/elmo/api/router.py
+++ b/elmo/api/router.py
@@ -13,19 +13,19 @@ class Router(object):
 
     @property
     def lock(self):
-        return "{}/api/panel/syncLogin".format(self._base_url)
+        return "{}/api/panel/syncLogin".format(self._api_url)
 
     @property
     def unlock(self):
-        return "{}/api/panel/syncLogout".format(self._base_url)
+        return "{}/api/panel/syncLogout".format(self._api_url)
 
     @property
     def send_command(self):
-        return "{}/api/panel/syncSendCommand".format(self._base_url)
+        return "{}/api/panel/syncSendCommand".format(self._api_url)
 
     @property
     def areas(self):
-        return "{}/api/areas".format(self._base_url)
+        return "{}/api/areas".format(self._api_url)
 
     @property
     def areas_list(self):
@@ -34,7 +34,7 @@ class Router(object):
 
     @property
     def inputs(self):
-        return "{}/api/inputs".format(self._base_url)
+        return "{}/api/inputs".format(self._api_url)
 
     @property
     def inputs_list(self):

--- a/elmo/api/router.py
+++ b/elmo/api/router.py
@@ -3,13 +3,16 @@ class Router(object):
     grouped by action type.
     """
 
-    def __init__(self, base_url, vendor):
-        self._vendor = vendor
+    def __init__(self, base_url):
         self._base_url = base_url
 
     @property
     def auth(self):
-        return "{}/{}".format(self._base_url, self._vendor)
+        return "{}/api/login".format(self._base_url)
+
+    @property
+    def strings(self):
+        return "{}/api/strings".format(self._base_url)
 
     @property
     def lock(self):
@@ -28,15 +31,5 @@ class Router(object):
         return "{}/api/areas".format(self._base_url)
 
     @property
-    def areas_list(self):
-        # Returns a HTML page that requires parsing
-        return "{}/{}/Areas".format(self._base_url, self._vendor)
-
-    @property
     def inputs(self):
         return "{}/api/inputs".format(self._base_url)
-
-    @property
-    def inputs_list(self):
-        # Returns a HTML page that requires parsing
-        return "{}/{}/Inputs".format(self._base_url, self._vendor)

--- a/elmo/utils/parser.py
+++ b/elmo/utils/parser.py
@@ -1,27 +1,4 @@
-from uuid import UUID
 from bs4 import BeautifulSoup
-import re
-
-
-def get_access_token(html):
-    """Retrieve the access token from a HTML page.
-
-    Args:
-        html: the HTML body containing the access token
-    Returns:
-        A string with the access token, None otherwise
-    """
-    start = html.find("var sessionId = '") + 17
-    end = start + 36
-    token = html[start:end]
-
-    try:
-        # Validate if the token is a valid UUID
-        UUID(token, version=4)
-    except ValueError:
-        token = None
-
-    return token
 
 
 def get_listed_items(html):
@@ -37,16 +14,3 @@ def get_listed_items(html):
     tree = BeautifulSoup(html, "html.parser")
     rows = tree.select("tbody > tr")
     return [x.getText().split("\n")[1] for x in rows]
-
-
-def get_api_url(html):
-    """Retrieve the url for API requests from a HTML page.
-
-    Args:
-        html: the HTML body containing the apiURL
-    Returns:
-        A string with the apiURL, None otherwise
-    """
-    apiURL = re.search(r"var apiURL = '(.+)/api/';", html).group(1)
-
-    return apiURL

--- a/elmo/utils/parser.py
+++ b/elmo/utils/parser.py
@@ -1,6 +1,6 @@
 from uuid import UUID
-
 from bs4 import BeautifulSoup
+import re
 
 
 def get_access_token(html):
@@ -37,3 +37,17 @@ def get_listed_items(html):
     tree = BeautifulSoup(html, "html.parser")
     rows = tree.select("tbody > tr")
     return [x.getText().split("\n")[1] for x in rows]
+
+
+def get_api_url(html):
+    """Retrieve the url for API requests from a HTML page.
+
+    Args:
+        html: the HTML body containing the apiURL
+    Returns:
+        A string with the apiURL, None otherwise
+    """
+    apiURL = re.search(r"var apiURL = '(.+)/api/';", html).group(1)
+
+    return apiURL
+    

--- a/elmo/utils/parser.py
+++ b/elmo/utils/parser.py
@@ -50,4 +50,3 @@ def get_api_url(html):
     apiURL = re.search(r"var apiURL = '(.+)/api/';", html).group(1)
 
     return apiURL
-    

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -35,8 +35,10 @@ def test_require_session_missing():
             return 42
 
     client = TestClient()
-    with pytest.raises(PermissionDenied):
+    with pytest.raises(PermissionDenied) as excinfo:
         client.action()
+
+    assert str(excinfo.value) == "You do not have permission to perform this action."
 
 
 def test_require_lock():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,33 +1,5 @@
-from elmo.utils.parser import get_access_token, get_listed_items
+from elmo.utils.parser import get_listed_items
 from elmo.utils.response_helper import slice_list
-
-
-def test_retrieve_access_token():
-    """Should retrieve an access token from the given HTML page."""
-    html = """<script type="text/javascript">
-        var apiURL = 'https://example.com';
-        var sessionId = '00000000-0000-0000-0000-000000000000';
-        var canElevate = '1';
-    """
-    token = get_access_token(html)
-    assert token == "00000000-0000-0000-0000-000000000000"
-
-
-def test_retrieve_access_token_wrong():
-    """Should retrieve an access token from the given HTML page."""
-    html = """<script type="text/javascript">
-        var apiURL = 'https://example.com';
-        var sessionId = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
-        var canElevate = '1';
-    """
-    token = get_access_token(html)
-    assert token is None
-
-
-def test_retrieve_access_token_empty():
-    """Should retrieve an access token from the given HTML page."""
-    token = get_access_token("")
-    assert token is None
 
 
 def test_retrieve_areas_names(areas_html):


### PR DESCRIPTION
### Overview

Follow-up of #44 

This PR introduces the Authentication API instead of using a form and parsing the `SessionID` from the web page. Introduced changes are:
* Uses `<base_url>/api/login` endpoint to grab the `session_id`
* A failed authentication raises `HTTPError` instead of `PermissionDenied`. `PermissionDenied` exception is used only when a `session_id` is not available
* Removes `get_access_token()`