### PR TITLE
Make client.query() a public API

### DIFF
--- a/elmo/api/client.py
+++ b/elmo/api/client.py
@@ -241,9 +241,15 @@ class ElmoClient(object):
         return descriptions
 
     @require_session
-    def _query(self, query):
+    def query(self, query):
         """Query an Elmo System to retrieve registered entries. Items are grouped
-        by "Active" status.
+        by "Active" status. It's possible to query different part of the system
+        using the `elmo.query` module:
+
+            from elmo import query
+
+            sectors_armed, sectors_disabled = client.query(query.SECTORS)
+            inputs_alerted, inputs_wait = client.query(query.INPUTS)
 
         Raises:
             QueryNotValid: if the query is not recognized.
@@ -297,6 +303,9 @@ class ElmoClient(object):
             * If the alarm for each sector is armed or disarmed
             * If the alarm for each input is in alerted state or not
 
+        This method is considered a shortcut that calls `client.query()` with `SECTORS`
+        and `INPUTS` queries.
+
         Raises:
             HTTPError: if there is an error raised by the API (not 2xx response).
         Returns:
@@ -310,8 +319,8 @@ class ElmoClient(object):
             }
         """
         # Retrieve sectors and inputs
-        sectors_armed, sectors_disarmed = self._query(q.SECTORS)
-        inputs_alerted, inputs_wait = self._query(q.INPUTS)
+        sectors_armed, sectors_disarmed = self.query(q.SECTORS)
+        inputs_alerted, inputs_wait = self.query(q.INPUTS)
 
         return {
             "sectors_armed": sectors_armed,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -612,7 +612,7 @@ def test_client_get_descriptions_error(server, client):
 
 def test_client_get_sectors_status(server, client, sectors_json, mocker):
     """Should query a Elmo system to retrieve sectors status."""
-    # _query() depends on _get_descriptions()
+    # query() depends on _get_descriptions()
     server.add(
         responses.POST, "https://example.com/api/areas", body=sectors_json, status=200
     )
@@ -621,7 +621,7 @@ def test_client_get_sectors_status(server, client, sectors_json, mocker):
         9: {0: "Living Room", 1: "Bedroom", 2: "Kitchen", 3: "Entryway"},
     }
     client._session_id = "test"
-    sectors_armed, sectors_disarmed = client._query(query.SECTORS)
+    sectors_armed, sectors_disarmed = client.query(query.SECTORS)
     # Expected output
     assert client._get_descriptions.called is True
     assert len(server.calls) == 1
@@ -636,7 +636,7 @@ def test_client_get_sectors_status(server, client, sectors_json, mocker):
 
 def test_client_get_inputs(server, client, inputs_json, mocker):
     """Should query a Elmo system to retrieve inputs status."""
-    # _query() depends on _get_descriptions()
+    # query() depends on _get_descriptions()
     server.add(
         responses.POST, "https://example.com/api/inputs", body=inputs_json, status=200
     )
@@ -645,7 +645,7 @@ def test_client_get_inputs(server, client, inputs_json, mocker):
         10: {0: "Alarm", 1: "Window kitchen", 2: "Door entryway", 3: "Window bathroom"},
     }
     client._session_id = "test"
-    inputs_alerted, inputs_wait = client._query(query.INPUTS)
+    inputs_alerted, inputs_wait = client.query(query.INPUTS)
     # Expected output
     assert client._get_descriptions.called is True
     assert len(server.calls) == 1
@@ -662,7 +662,7 @@ def test_client_query_not_valid(client):
     """Should raise QueryNotValid if the query is not recognized."""
     client._session_id = "test"
     with pytest.raises(QueryNotValid):
-        client._query("wrong_query")
+        client.query("wrong_query")
 
 
 def test_client_query_unauthorized(server, client, mocker):
@@ -676,7 +676,7 @@ def test_client_query_unauthorized(server, client, mocker):
     client._session_id = "test"
     mocker.patch.object(client, "_get_descriptions")
     with pytest.raises(HTTPError):
-        client._query(query.SECTORS)
+        client.query(query.SECTORS)
 
 
 def test_client_query_error(server, client, mocker):
@@ -687,13 +687,13 @@ def test_client_query_error(server, client, mocker):
     client._session_id = "test"
     mocker.patch.object(client, "_get_descriptions")
     with pytest.raises(HTTPError):
-        client._query(query.SECTORS)
+        client.query(query.SECTORS)
 
 
 def test_client_check_success(server, client, sectors_json, inputs_json, mocker):
     """Should check the global status of an Elmo System. This test runs
-    as a full test and doesn't mock the `client._query()` method. Without
-    mocks, the contract from `client._query()` is verified.
+    as a full test and doesn't mock the `client.query()` method. Without
+    mocks, the contract from `client.query()` is verified.
     """
     # Check depends on querying sectors/inputs endpoints
     server.add(


### PR DESCRIPTION
### Overview

This PR makes the `client._query()` a public API. Now it's possible to query individual parts of the system as follows:
```python
from elmo import query

sectors_armed, sectors_disabled = client.query(query.SECTORS)
inputs_alerted, inputs_wait = client.query(query.INPUTS)
```

Client `check()` method is now considered a shortcut that returns a `dict` for the entire status of the system.